### PR TITLE
Create a new session for each Token

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"

--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ The package is available as open source under the terms of the [MIT License](htt
 
 ## Changelog
 
+- **1.2.4** Create a new session for each Token.
 - **1.2.3** Check if IOBase when checking to see if something is a file.
 - **1.2.2** Strip domain from URLs provided to token.* methods.
 - **1.2.1** Update sandbox URLs from uat => sandbox.

--- a/dwollav2/test/test_token.py
+++ b/dwollav2/test/test_token.py
@@ -33,6 +33,16 @@ class TokenShould(unittest2.TestCase):
         token = self.client.Token(account_id=self.account_id)
         self.assertEqual(self.account_id, token.account_id)
 
+    def test_uses_new_session(self):
+        new_access_token = 'new access token'
+
+        token1 = self.client.Token(access_token=self.access_token)
+        token2 = self.client.Token(access_token=new_access_token)
+
+        self.assertNotEqual(token1.session, token2.session)
+        self.assertEqual(token1.session.headers['authorization'], 'Bearer %s' % self.access_token)
+        self.assertEqual(token2.session.headers['authorization'], 'Bearer %s' % new_access_token)
+
     @responses.activate
     def test_get_success(self):
         responses.add(responses.GET,

--- a/dwollav2/token.py
+++ b/dwollav2/token.py
@@ -5,14 +5,6 @@ import re
 from dwollav2.response import Response
 from dwollav2.version import version
 
-
-session = requests.session()
-session.headers.update({
-    'accept': 'application/vnd.dwolla.v1.hal+json',
-    'user-agent': 'dwolla-v2-python %s' % version
-})
-
-
 def _items_or_iteritems(o):
     try:
         return o.iteritems()
@@ -49,7 +41,11 @@ def token_for(_client):
             self.scope         = opts.get('scope')
             self.app_id        = opts.get('app_id')
             self.account_id    = opts.get('account_id')
-            session.headers.update({
+
+            self.session = requests.session()
+            self.session.headers.update({
+                'accept': 'application/vnd.dwolla.v1.hal+json',
+                'user-agent': 'dwolla-v2-python %s' % version,
                 'authorization': 'Bearer %s' % self.access_token
             })
 
@@ -58,16 +54,16 @@ def token_for(_client):
             if _contains_file(body):
                 files = [(k, v) for k, v in _items_or_iteritems(body) if _contains_file(v)]
                 data = [(k, v) for k, v in _items_or_iteritems(body) if not _contains_file(v)]
-                return Response(session.post(self._full_url(url), headers=headers, files=files, data=data))
+                return Response(self.session.post(self._full_url(url), headers=headers, files=files, data=data))
             else:
-                return Response(session.post(self._full_url(url), headers=headers, json=body))
+                return Response(self.session.post(self._full_url(url), headers=headers, json=body))
 
         def get(self, url, params = None, headers = {}, **kwargs):
             params = kwargs if params is None else params
-            return Response(session.get(self._full_url(url), headers=headers, params=params))
+            return Response(self.session.get(self._full_url(url), headers=headers, params=params))
 
         def delete(self, url, params = None, headers = {}):
-            return Response(session.delete(self._full_url(url), headers=headers, params=params))
+            return Response(self.session.delete(self._full_url(url), headers=headers, params=params))
 
         def _full_url(self, path):
             if isinstance(path, dict):

--- a/dwollav2/version.py
+++ b/dwollav2/version.py
@@ -1,1 +1,1 @@
-version = '1.2.3'
+version = '1.2.4'

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ except ImportError:
 
 setup(
     name='dwollav2',
-    version='1.2.3',
+    version='1.2.4',
     packages=['dwollav2'],
     install_requires=[
         'requests>=2.9.1',


### PR DESCRIPTION
Currently, if you create a multiple clients for different credentials in the same process, the access token gets set on a session instance that is shared across Token classes. This can cause the wrong token to get used sometimes, especially if you are doing any kind of threading.

This PR will make it so each Token instance gets its own session instance.