### PR TITLE
v2.2: Update JSON request bodies to serialize via `simplejson`

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,9 @@ The package is available as open source under the terms of the [MIT License](htt
 
 ## Changelog
 
+- **2.2.0**
+  - Update JSON request bodies to serialize via `simplejson` so datatypes like `Decimal` still
+    serialize like they did pre `2.0.0`
 - **2.1.0**
   - Do not share `requests.session()` across instances of `dwollav2.Client`
 - **2.0.0**

--- a/dwollav2/token.py
+++ b/dwollav2/token.py
@@ -1,7 +1,11 @@
 import requests
 from io import IOBase
 import re
-import json
+
+try:
+    import simplejson as json
+except ImportError:
+    import json
 
 from dwollav2.response import Response
 from dwollav2.version import version

--- a/dwollav2/version.py
+++ b/dwollav2/version.py
@@ -1,1 +1,1 @@
-version = '2.1.0'
+version = '2.2.0'

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ except ImportError:
 
 setup(
     name='dwollav2',
-    version='2.1.0',
+    version='2.2.0',
     packages=['dwollav2'],
     install_requires=[
         'requests>=2.9.1',


### PR DESCRIPTION
Tested sending to the `/micro-deposits` endpoint

`payload`: was what I built and send to the `client`
`body` is what was passed into the `Token.post()`
`data` is what was passed into the request library from the `json.dumps` call

![image](https://user-images.githubusercontent.com/1547881/94183631-9134fc00-fe57-11ea-806f-08393b806c1e.png)
