### PR TITLE
Remove unnecessary future dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 requests>=2.27.0
 responses>=0.9.0
 unittest2>=1.1.0
-future>=0.16.0
 mock>=2.0.0

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ setup(
     packages=['dwollav2'],
     install_requires=[
         'requests>=2.9.1',
-        'future>=0.15.2'
     ],
     test_suite='dwollav2.test.all',
     url='https://docsv2.dwolla.com',


### PR DESCRIPTION
Removes `future` as a dependency, since the code does not use `from __future__ import ...`.

Two notes:

- tests don't run on python >= 3.10, so I'll submit a second PR
- `future` is not in `Pipfile`, but it is in `Pipfile.lock`. It's probably worth replacing these, `requirements.txt`, and `setup.py` with `pyproject.toml`, but the specifics will depend on how you're actually building and uploading to pypi.

Resolves #52 