### PR TITLE
Swap unittest2 for stdlib unittest so test work on modern python versions

### DIFF
--- a/dwollav2/test/__init__.py
+++ b/dwollav2/test/__init__.py
@@ -1,13 +1,13 @@
 import os
-import unittest2
+import unittest
 
 
 def all():
     path = os.path.dirname(os.path.realpath(__file__))
-    return unittest2.defaultTestLoader.discover(path)
+    return unittest.defaultTestLoader.discover(path)
 
 
 def resources():
     path = os.path.dirname(os.path.realpath(__file__))
-    return unittest2.defaultTestLoader.discover(
+    return unittest.defaultTestLoader.discover(
         os.path.join(path, "resources"))

--- a/dwollav2/test/test_auth.py
+++ b/dwollav2/test/test_auth.py
@@ -1,4 +1,4 @@
-import unittest2
+import unittest
 import responses
 from mock import Mock
 try:
@@ -9,7 +9,7 @@ except ImportError:
 import dwollav2
 
 
-class AuthShould(unittest2.TestCase):
+class AuthShould(unittest.TestCase):
     client = dwollav2.Client(id='id', secret='secret', on_grant=Mock())
     redirect_uri = 'redirect uri'
     scope = 'scope'

--- a/dwollav2/test/test_client.py
+++ b/dwollav2/test/test_client.py
@@ -1,10 +1,10 @@
-import unittest2
+import unittest
 import responses
 
 import dwollav2
 
 
-class ClientShould(unittest2.TestCase):
+class ClientShould(unittest.TestCase):
     id = 'client-id'
     secret = 'client-secret'
 

--- a/dwollav2/test/test_error.py
+++ b/dwollav2/test/test_error.py
@@ -1,10 +1,10 @@
-import unittest2
+import unittest
 import requests
 
 import dwollav2
 
 
-class ErrorShould(unittest2.TestCase):
+class ErrorShould(unittest.TestCase):
     def test_maps_string_to_generic_error(self):
         error = 'foo'
         with self.assertRaises(dwollav2.Error) as ecm:

--- a/dwollav2/test/test_response.py
+++ b/dwollav2/test/test_response.py
@@ -1,10 +1,10 @@
-import unittest2
+import unittest
 import requests
 
 import dwollav2
 
 
-class ResponseShould(unittest2.TestCase):
+class ResponseShould(unittest.TestCase):
     def test_raises_error_if_over_400(self):
         res = requests.Response()
         res.status_code = 400

--- a/dwollav2/test/test_token.py
+++ b/dwollav2/test/test_token.py
@@ -1,10 +1,10 @@
-import unittest2
+import unittest
 import responses
 
 import dwollav2
 
 
-class TokenShould(unittest2.TestCase):
+class TokenShould(unittest.TestCase):
     client = dwollav2.Client(id='id', secret='secret')
     access_token = 'access token'
     refresh_token = 'refresh token'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 requests>=2.27.0
 responses>=0.9.0
-unittest2>=1.1.0
 future>=0.16.0
 mock>=2.0.0


### PR DESCRIPTION
`unittest2` won't work on anything > Python 3.9, and it's only necessary for old versions that have reached EOL.

This change is the bare minimum to get tests to run with `pytest`, but the README calls out `python setup.py test`, which doesn't work anymore as that feature was removed from `setuptools`. You'll want to add `pytest` to dev requirements and possibly set up `tox` for multi-version testing.