### PR TITLE
Always handle Decimal objects in JSON

### DIFF
--- a/dwollav2/test/__init__.py
+++ b/dwollav2/test/__init__.py
@@ -1,13 +1,13 @@
 import os
-import unittest2
+import unittest
 
 
 def all():
     path = os.path.dirname(os.path.realpath(__file__))
-    return unittest2.defaultTestLoader.discover(path)
+    return unittest.defaultTestLoader.discover(path)
 
 
 def resources():
     path = os.path.dirname(os.path.realpath(__file__))
-    return unittest2.defaultTestLoader.discover(
+    return unittest.defaultTestLoader.discover(
         os.path.join(path, "resources"))

--- a/dwollav2/test/test_auth.py
+++ b/dwollav2/test/test_auth.py
@@ -1,4 +1,4 @@
-import unittest2
+import unittest
 import responses
 from mock import Mock
 try:
@@ -9,7 +9,7 @@ except ImportError:
 import dwollav2
 
 
-class AuthShould(unittest2.TestCase):
+class AuthShould(unittest.TestCase):
     client = dwollav2.Client(id='id', secret='secret', on_grant=Mock())
     redirect_uri = 'redirect uri'
     scope = 'scope'

--- a/dwollav2/test/test_client.py
+++ b/dwollav2/test/test_client.py
@@ -1,10 +1,10 @@
-import unittest2
+import unittest
 import responses
 
 import dwollav2
 
 
-class ClientShould(unittest2.TestCase):
+class ClientShould(unittest.TestCase):
     id = 'client-id'
     secret = 'client-secret'
 

--- a/dwollav2/test/test_error.py
+++ b/dwollav2/test/test_error.py
@@ -1,10 +1,10 @@
-import unittest2
+import unittest
 import requests
 
 import dwollav2
 
 
-class ErrorShould(unittest2.TestCase):
+class ErrorShould(unittest.TestCase):
     def test_maps_string_to_generic_error(self):
         error = 'foo'
         with self.assertRaises(dwollav2.Error) as ecm:

--- a/dwollav2/test/test_response.py
+++ b/dwollav2/test/test_response.py
@@ -1,10 +1,10 @@
-import unittest2
+import unittest
 import requests
 
 import dwollav2
 
 
-class ResponseShould(unittest2.TestCase):
+class ResponseShould(unittest.TestCase):
     def test_raises_error_if_over_400(self):
         res = requests.Response()
         res.status_code = 400

--- a/dwollav2/test/test_token.py
+++ b/dwollav2/test/test_token.py
@@ -1,3 +1,4 @@
+import decimal
 import unittest
 import responses
 
@@ -163,3 +164,15 @@ class TokenShould(unittest.TestCase):
         res = token.delete('foo', None, self.more_headers)
         self.assertEqual(200, res.status)
         self.assertEqual({'foo': 'bar'}, res.body)
+
+    @responses.activate
+    def test_post_decimal(self):
+        responses.add(responses.POST,
+                      self.client.api_url + '/foo',
+                      body='{"amount": "12.34"}',
+                      status=200,
+                      content_type='application/vnd.dwolla.v1.hal+json')
+        token = self.client.Token(access_token=self.access_token)
+        res = token.post('foo', body={'amount': decimal.Decimal('12.34')})
+        self.assertEqual(200, res.status)
+        self.assertEqual({'amount': '12.34'}, res.body)

--- a/dwollav2/test/test_token.py
+++ b/dwollav2/test/test_token.py
@@ -1,10 +1,10 @@
-import unittest2
+import unittest
 import responses
 
 import dwollav2
 
 
-class TokenShould(unittest2.TestCase):
+class TokenShould(unittest.TestCase):
     client = dwollav2.Client(id='id', secret='secret')
     access_token = 'access token'
     refresh_token = 'refresh token'

--- a/dwollav2/token.py
+++ b/dwollav2/token.py
@@ -1,14 +1,18 @@
 import requests
 from io import IOBase
 import re
-
-try:
-    import simplejson as json
-except ImportError:
-    import json
+import json
+import decimal
 
 from dwollav2.response import Response
 from dwollav2.version import version
+
+
+class DecimalEncoder(json.JSONEncoder):
+    def default(self, o):
+        if isinstance(o, decimal.Decimal):
+            return str(o)
+        return super().default(o)
 
 
 def _items_or_iteritems(o):
@@ -74,7 +78,7 @@ def token_for(_client):
                     self._full_url(url),
                     headers=self._merge_dicts(
                         {'content-type': 'application/json'}, headers),
-                    data=json.dumps(body, sort_keys=True, indent=2),
+                    data=json.dumps(body, sort_keys=True, indent=2, cls=DecimalEncoder),
                     **requests))
 
         def get(self, url, params=None, headers={}, **kwargs):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 requests>=2.27.0
 responses>=0.9.0
-unittest2>=1.1.0
 future>=0.16.0
 mock>=2.0.0


### PR DESCRIPTION
Removes implicit use of `simplejson` by using standard Python `JSONEncoder` class.

Fixes #55 . Right now it includes the testing changes from #54 so that I could include a new test. When that is merged separately this can be evaluated just for `token.py` and `test_token.py`.