### PR TITLE
Always handle Decimal objects in JSON 

### DIFF
--- a/dwollav2/test/test_token.py
+++ b/dwollav2/test/test_token.py
@@ -1,3 +1,4 @@
+import decimal
 import unittest
 import responses
 
@@ -163,3 +164,15 @@ class TokenShould(unittest.TestCase):
         res = token.delete('foo', None, self.more_headers)
         self.assertEqual(200, res.status)
         self.assertEqual({'foo': 'bar'}, res.body)
+
+    @responses.activate
+    def test_post_decimal(self):
+        responses.add(responses.POST,
+                      self.client.api_url + '/foo',
+                      body='{"amount": "12.34"}',
+                      status=200,
+                      content_type='application/vnd.dwolla.v1.hal+json')
+        token = self.client.Token(access_token=self.access_token)
+        res = token.post('foo', body={'amount': decimal.Decimal('12.34')})
+        self.assertEqual(200, res.status)
+        self.assertEqual({'amount': '12.34'}, res.body)

--- a/dwollav2/token.py
+++ b/dwollav2/token.py
@@ -1,14 +1,18 @@
 import requests
 from io import IOBase
 import re
-
-try:
-    import simplejson as json
-except ImportError:
-    import json
+import json
+import decimal
 
 from dwollav2.response import Response
 from dwollav2.version import version
+
+
+class DecimalEncoder(json.JSONEncoder):
+    def default(self, o):
+        if isinstance(o, decimal.Decimal):
+            return str(o)
+        return super().default(o)
 
 
 def _items_or_iteritems(o):
@@ -74,7 +78,7 @@ def token_for(_client):
                     self._full_url(url),
                     headers=self._merge_dicts(
                         {'content-type': 'application/json'}, headers),
-                    data=json.dumps(body, sort_keys=True, indent=2),
+                    data=json.dumps(body, sort_keys=True, indent=2, cls=DecimalEncoder),
                     **requests))
 
         def get(self, url, params=None, headers={}, **kwargs):


### PR DESCRIPTION
Removes implicit use of simplejson by using standard Python JSONEncoder class.

Fixes #55, and replaces #56 