### PR TITLE
fix: update Python version to 3.8 for GitHub Actions compatibility

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: '3.7'
+          python-version: '3.8'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
Python 3.7 is no longer available in GitHub Actions runners (EOL June 2023).
Updated to Python 3.8 to resolve deployment failures while maintaining 
backward compatibility.